### PR TITLE
Refactor from submodules to hugo modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/book"]
-	path = themes/book
-	url = https://github.com/alex-shpak/hugo-book

--- a/config.yaml
+++ b/config.yaml
@@ -3,8 +3,16 @@
 baseURL: https://picaroons.netlify.app/
 title: Picaroons
 description: Narrative adventures as scoundrels
-theme: book
+# Google Analytics code
 googleAnalytics: G-4KSV7MVQ0D
+
+module:
+  # Dev use only!
+  # Only used in local testing; make sure to override the path to your own local copy
+  # replacements: 'github.com/platenio/hugo-platen -> C:\code\platen\themes\platen'
+  imports:
+    - path: github.com/platenio/hugo-platen
+    - path: github.com/alex-shpak/hugo-book
 
 # Book configuration
 disablePathToLower: true
@@ -44,6 +52,8 @@ menu:
       weight: 10
 
 params:
+  # Sets image to use for the OpenGraph configuration:
+  # - https://gohugo.io/templates/internal/#open-graph
   images:
     - images/picaroons.png
   # (Optional, default light) Sets color theme: light, dark or auto.

--- a/content/_index.md
+++ b/content/_index.md
@@ -20,22 +20,48 @@ It also includes 6 picaresques, adventure kickstarts to drop you in media res an
 You can also buy Picaroons on itch, where it is itchfunding!
 Buying a copy gets you a print-at-home PDF as well as as the EPUB release.
 
-<iframe frameborder="0" src="https://itch.io/embed/1167997?linkback=true" width="552" height="167"><a href="https://michaeltlombardi.itch.io/picaroons">Picaroons by Michael T Lombardi</a></iframe>
+<iframe title="Itch Link for Purchasing Picaroons"
+        frameborder="0"
+        src="https://itch.io/embed/1167997?linkback=true"
+        width="552"
+        height="167">
+      <a href="https://michaeltlombardi.itch.io/picaroons">
+            Picaroons by Michael T Lombardi
+      </a>
+</iframe>
 
-- [x] **$200 USD:** I'll be able to afford proper editing of the core book. Minimum price will rise $2USD!
-- [ ] **$500 USD:** I'll be able to afford layout of the core book. Minimum price will rise $1USD!
-- [ ] **$750 USD:**  I'll be able to afford custom character sheets. Minimum price will rise $1USD!
-- [ ] **$1000 USD:** I'll be able to afford an initial print run of the core book, details to follow as we close in on this goal.
-- [ ] **$1250 USD:** I'll have actually been remunerated for some of the writing!
-      As the remaining zines are completed, I'll add itchfunding projectsfor them as well.
-      In the meantime, you can pre-buy them as add-ons!
-      Note that their minimum price will go up as they get completed, so buying early is also buying at a discount!
+### ✔ $200 USD
+
+I'll be able to afford proper editing of the core book. Minimum price will rise $2USD!
+
+### ✔ $500 USD
+
+I'll be able to afford layout of the core book. Minimum price will rise $1USD!
+
+### ❓ $750 USD
+
+I'll be able to afford custom character sheets. Minimum price will rise $1USD!
+
+### ❓ $1000 USD
+
+I'll be able to afford an initial print run of the core book, details to follow as we close in on this goal.
+
+### ❓ $1250 USD
+
+I'll have actually been remunerated for some of the writing!
+As the remaining zines are completed, I'll add itchfunding projectsfor them as well.
+In the meantime, you can pre-buy them as add-ons!
+Note that their minimum price will go up as they get completed, so buying early is also buying at a discount!
 
 ## Upcoming Projects
 
 ### Scrivener's Kit
 
-![A mockup of the Scrivener's Kit supplementary zine, courtesy of Chris Bissette](/images/mockups/ScrivenersKit.png)
+{{< art src="/images/mockups/ScrivenersKit.png"
+        alt="Mockup of the Scrivener's Kit zine, featuring a man staring in thought at a paper he is writing on, surrounded by stacks of books"
+>}}
+A mockup of the Scrivener's Kit supplementary zine, courtesy of Chris Bissette
+{{</ art >}}
 
 In this zine, guidance for the player(s) running  Picaroons through adventures, featuring:
 
@@ -45,7 +71,11 @@ In this zine, guidance for the player(s) running  Picaroons through adventures, 
 
 ### Tricks of the Trade
 
-![Mockup of the Tricks of the Trade supplementary zine, courtesy of Chris Bissette](/images/mockups/TricksOfTheTrade.png)
+{{< art src="/images/mockups/TricksOfTheTrade.png"
+        alt="Mockup of the Tricks of the Trade zine, featuring a man in a green hat and rusty brown jacket carrying a walking stick and a bundle of carpets, smoking a pipe"
+>}}
+Mockup of the Tricks of the Trade supplementary zine, courtesy of Chris Bissette
+{{</ art >}}
 
 In this zine, examples of tricks and subsystems to expand on them, featuring:
 
@@ -55,7 +85,11 @@ In this zine, examples of tricks and subsystems to expand on them, featuring:
 
 ### Questing Curios
 
-![Mockup of the Questing Curios supplementary zine, courtesy of Chris Bissette](/images/mockups/QuestingCurios.png)
+{{< art src="/images/mockups/QuestingCurios.png"
+        alt="Mockup of the Questing Curios zine, featuring a man in black pants, white shirt, red vest, turban, and yellow slippers sharpening a blade on a foot-powered grindstone"
+>}}
+Mockup of the Questing Curios supplementary zine, courtesy of Chris Bissette
+{{</ art >}}
 
 In this zine, examples of domains-as-items, featuring:
 
@@ -66,7 +100,11 @@ In this zine, examples of domains-as-items, featuring:
 
 ### Palatial Shadows
 
-![Mockup of the Palatial Shadows adventure zine, courtesy of Chris Bissette](/images/mockups/PalatialShadows.png)
+{{< art src="/images/mockups/PalatialShadows.png"
+        alt="Mockup of the Palatial Shadows zine, featuring an illustration of an opulent Palace set upon a hill overlooking a town"
+>}}
+Mockup of the Palatial Shadows adventure zine, courtesy of Chris Bissette
+{{</ art >}}
 
 In this zine, an urban hexflower featuring:
 

--- a/content/docs/picaroons/_index.md
+++ b/content/docs/picaroons/_index.md
@@ -15,4 +15,4 @@ It currently includes lightweight rules for adjudication, character creation/adv
 
 You can also buy _Picaroons_ on itch, where it is itchfunding!
 
-<iframe frameborder="0" src="https://itch.io/embed/1167997?linkback=true" width="552" height="167"><a href="https://michaeltlombardi.itch.io/picaroons">Picaroons by Michael T Lombardi</a></iframe>
+<iframe title="Link to Purchase Picaroons on Itch" frameborder="0" src="https://itch.io/embed/1167997?linkback=true" width="552" height="167"><a href="https://michaeltlombardi.itch.io/picaroons">Picaroons by Michael T Lombardi</a></iframe>

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/michaeltlombardi/picaroons
+
+go 1.16
+
+require (
+	github.com/alex-shpak/hugo-book v0.0.0-20210907200533-6aef8ef1c776 // indirect
+	github.com/platenio/hugo-platen v0.0.0-20210908032145-33863a0ed75f // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/alex-shpak/hugo-book v0.0.0-20210907200533-6aef8ef1c776 h1:wRep+NGTXIK1oNLj0gHKEAcYrdFD8+Qh+OfGx3Mzbrw=
+github.com/alex-shpak/hugo-book v0.0.0-20210907200533-6aef8ef1c776/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=
+github.com/platenio/hugo-platen v0.0.0-20210908032145-33863a0ed75f h1:yfy8aysH2gu8AYOwV133aimIGxosqqjwDa8g3h4Eqlw=
+github.com/platenio/hugo-platen v0.0.0-20210908032145-33863a0ed75f/go.mod h1:oKKoHERB/TNznzstUQiRFuVaqMyk/l8jtUTXR1M+6bk=


### PR DESCRIPTION
This commit refactors the project to migrate from using the hugo-book theme
as a submodule and towards using it and the hugo-platen theme itself as
hugo modules. This is more maintainable and does not require teaching
users how to work with git submodules at all.